### PR TITLE
feat: provide dazlVitePlugin for a direct usage within projects 

### DIFF
--- a/packages/dev/package.json
+++ b/packages/dev/package.json
@@ -7,7 +7,16 @@
     ".": "./dist/jsx-runtime.js",
     "./jsx-runtime": "./dist/jsx-runtime.js",
     "./jsx-dev-runtime": "./dist/jsx-runtime.js",
+    "./dazl-vite-plugin": "./dist/dazl-vite-plugin.js",
     "./package.json": "./package.json"
+  },
+  "peerDependencies": {
+    "vite": ">=7.0.0"
+  },
+  "peerDependenciesMeta": {
+    "vite": {
+      "optional": true
+    }
   },
   "files": [
     "dist",

--- a/packages/dev/src/dazl-vite-plugin.ts
+++ b/packages/dev/src/dazl-vite-plugin.ts
@@ -1,0 +1,23 @@
+import { pathToFileURL } from 'node:url';
+import { version as viteVersion } from 'vite';
+import type { PluginOption } from 'vite';
+
+interface DazlVitePluginOptions {
+    previewScriptUrl?: string;
+    viteVersion?: string;
+}
+
+type DazlPlugins = (options: DazlVitePluginOptions) => Promise<PluginOption[]>;
+
+/** Loads the dazl vite plugin from the env vars dazl sets when starting the dev server (no-op otherwise). */
+export async function dazlVitePlugin(): Promise<PluginOption> {
+    const pluginPath = process.env.DAZL_PLUGIN_PATH;
+    const previewScriptUrl = process.env.DAZL_PREVIEW_SCRIPT_URL;
+    if (!pluginPath || !previewScriptUrl) {
+        return false;
+    }
+
+    const { default: dazlPlugins } = (await import(pathToFileURL(pluginPath).href)) as { default: DazlPlugins };
+
+    return dazlPlugins({ viteVersion, previewScriptUrl });
+}


### PR DESCRIPTION
## Why

When dazl starts a project's dev server with a custom `startScript`, it exposes the dazl vite plugin and preview script via env vars instead of generating a vite config. Projects need a simple way to wire that plugin into their own vite config; this helper does it in one line.

## Tech Details

- New `@dazl/dev/dazl-vite-plugin` export. `dazlVitePlugin()` reads `DAZL_PLUGIN_PATH` and `DAZL_PREVIEW_SCRIPT_URL`, dynamically imports the plugin module, and returns it configured with the current project vite version. When the env vars aren't set (project running standalone) it returns `false`, a no-op vite plugin.
- Declares `vite` as an optional peer dependency: only the new helper imports from `vite` (the project supplies its own), and it's optional so projects using only the existing jsx-runtime export aren't warned about a missing peer.


## Product Details

Projects whose dev server is launched by dazl can add `dazlVitePlugin()` to their `vite.config` plugins and get the dazl preview/editing integration, while the same config still works when run on its own.
