### PR TITLE
fix: accept file:// url in DAZL_PLUGIN_PATH without re-resolving

### DIFF
--- a/packages/dev/src/dazl-vite-plugin.ts
+++ b/packages/dev/src/dazl-vite-plugin.ts
@@ -1,4 +1,3 @@
-import { pathToFileURL } from 'node:url';
 import { version as viteVersion } from 'vite';
 import type { PluginOption } from 'vite';
 
@@ -11,13 +10,12 @@ type DazlPlugins = (options: DazlVitePluginOptions) => Promise<PluginOption[]>;
 
 /** Loads the dazl vite plugin from the env vars dazl sets when starting the dev server (no-op otherwise). */
 export async function dazlVitePlugin(): Promise<PluginOption> {
-    const pluginPath = process.env.DAZL_PLUGIN_PATH;
+    const pluginUrl = process.env.DAZL_PLUGIN_PATH;
     const previewScriptUrl = process.env.DAZL_PREVIEW_SCRIPT_URL;
-    if (!pluginPath || !previewScriptUrl) {
+    if (!pluginUrl || !previewScriptUrl) {
         return false;
     }
 
-    const pluginUrl = pluginPath.startsWith('file:') ? pluginPath : pathToFileURL(pluginPath).href;
     const { default: dazlPlugins } = (await import(pluginUrl)) as { default: DazlPlugins };
 
     return dazlPlugins({ viteVersion, previewScriptUrl });

--- a/packages/dev/src/dazl-vite-plugin.ts
+++ b/packages/dev/src/dazl-vite-plugin.ts
@@ -17,7 +17,8 @@ export async function dazlVitePlugin(): Promise<PluginOption> {
         return false;
     }
 
-    const { default: dazlPlugins } = (await import(pathToFileURL(pluginPath).href)) as { default: DazlPlugins };
+    const pluginUrl = pluginPath.startsWith('file:') ? pluginPath : pathToFileURL(pluginPath).href;
+    const { default: dazlPlugins } = (await import(pluginUrl)) as { default: DazlPlugins };
 
     return dazlPlugins({ viteVersion, previewScriptUrl });
 }


### PR DESCRIPTION
`dazlVitePlugin()` wrapped `process.env.DAZL_PLUGIN_PATH` in `pathToFileURL()` before importing it. But the dazl dev server sets that env var to an **already-resolved `file://` url**

Fix by keeping the url as-is
