### PR TITLE
fix: resolve @dazl/dev types under moduleResolution node10

### DIFF
--- a/packages/dev/package.json
+++ b/packages/dev/package.json
@@ -3,7 +3,13 @@
   "version": "1.5.0",
   "description": "Dazl development time utilities.",
   "type": "module",
-  "main": "./dist/jsx-runtime.js",
+  "exports": {
+    ".": "./dist/jsx-runtime.js",
+    "./jsx-runtime": "./dist/jsx-runtime.js",
+    "./jsx-dev-runtime": "./dist/jsx-runtime.js",
+    "./dazl-vite-plugin": "./dist/dazl-vite-plugin.js",
+    "./package.json": "./package.json"
+  },
   "types": "./dist/jsx-runtime.d.ts",
   "typesVersions": {
     "*": {
@@ -11,13 +17,6 @@
       "jsx-dev-runtime": ["./dist/jsx-runtime.d.ts"],
       "dazl-vite-plugin": ["./dist/dazl-vite-plugin.d.ts"]
     }
-  },
-  "exports": {
-    ".": "./dist/jsx-runtime.js",
-    "./jsx-runtime": "./dist/jsx-runtime.js",
-    "./jsx-dev-runtime": "./dist/jsx-runtime.js",
-    "./dazl-vite-plugin": "./dist/dazl-vite-plugin.js",
-    "./package.json": "./package.json"
   },
   "peerDependencies": {
     "vite": ">=7.0.0"

--- a/packages/dev/package.json
+++ b/packages/dev/package.json
@@ -3,6 +3,15 @@
   "version": "1.5.0",
   "description": "Dazl development time utilities.",
   "type": "module",
+  "main": "./dist/jsx-runtime.js",
+  "types": "./dist/jsx-runtime.d.ts",
+  "typesVersions": {
+    "*": {
+      "jsx-runtime": ["./dist/jsx-runtime.d.ts"],
+      "jsx-dev-runtime": ["./dist/jsx-runtime.d.ts"],
+      "dazl-vite-plugin": ["./dist/dazl-vite-plugin.d.ts"]
+    }
+  },
   "exports": {
     ".": "./dist/jsx-runtime.js",
     "./jsx-runtime": "./dist/jsx-runtime.js",


### PR DESCRIPTION
`@dazl/dev` currently exposes its types only through the `exports` map. 

Consumers with old `moduleResolution: "node"` (`node10`) still existing and don't read `exports` and errors.

## Fix

Add the legacy resolution fields for `node10` alongside `exports` which modern resolvers (`bundler`/`node16`/`nodenext`) prefer: 

- `types`: the bare `@dazl/dev` import
- `typesVersions`: the subpath imports (`@dazl/dev/dazl-vite-plugin`, `/jsx-runtime`, `/jsx-dev-runtime`), which node10 can't resolve via `exports`

> No files need to live at the package root. `typesVersions` is a pre-file-lookup remap, so it points node10 at the existing `dist/*.d.ts`. Runtime subpath resolution is unaffected - it's handled by `exports`, which Vite and modern Node honor regardless of any tsconfig setting.
